### PR TITLE
Add typing for common resources and split up ns vs clusterscoped objects

### DIFF
--- a/app/cue.mod/module.cue
+++ b/app/cue.mod/module.cue
@@ -7,7 +7,7 @@ source: {
 }
 deps: {
 	"github.com/amir-ahmad/cue-k8s-modules/k8s-schema@v0": {
-		v:       "v0.1.0"
+		v:       "v0.2.0"
 		default: true
 	}
 }

--- a/app/examples/multi-app-package/app.cue
+++ b/app/examples/multi-app-package/app.cue
@@ -15,7 +15,7 @@ abstracted_app=app: [Name=string]: pkg_app.#AppConfig & {
 		pod: env: TZ: string | null | *"Australia/Sydney"
 	}
 
-	object: PersistentVolumeClaim: [string]: k8s.#PersistentVolumeClaim & {
+	object: namespaced: PersistentVolumeClaim: [string]: k8s.#PersistentVolumeClaim & {
 		spec: accessModes: [...string] | *["ReadWriteOnce"]
 	}
 

--- a/app/examples/multi-app-package/apps/foobar/foobar.cue
+++ b/app/examples/multi-app-package/apps/foobar/foobar.cue
@@ -42,7 +42,7 @@ app: foobar: {
 		pod: image: "job:v1"
 	}
 
-	object: PersistentVolumeClaim: "foo-pvc": spec: {
+	object: namespaced: PersistentVolumeClaim: "foo-pvc": spec: {
 		resources: requests: storage: "10gb"
 		storageClassName: "local"
 	}

--- a/app/k8s/k8s.cue
+++ b/app/k8s/k8s.cue
@@ -7,6 +7,7 @@ import (
 	batch_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/k8s.io/api/batch/v1"
 	storage_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/k8s.io/api/storage/v1"
 	meta_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbac_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/k8s.io/api/rbac/v1"
 )
 
 #StatefulSet: apps_v1.#StatefulSet & {
@@ -49,6 +50,11 @@ import (
 	kind:       "ConfigMap"
 }
 
+#Secret: core_v1.#Secret & {
+	apiVersion: "v1"
+	kind:       "Secret"
+}
+
 #StorageClass: storage_v1.#StorageClass & {
 	apiVersion: "storage.k8s.io/v1"
 	kind:       "StorageClass"
@@ -62,6 +68,36 @@ import (
 #PersistentVolumeClaim: core_v1.#PersistentVolumeClaim & {
 	apiVersion: "v1"
 	kind:       "PersistentVolumeClaim"
+}
+
+#ServiceAccount: core_v1.#ServiceAccount & {
+	apiVersion: "v1"
+	kind:       "ServiceAccount"
+}
+
+#Role: rbac_v1.#Role & {
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	kind:       "Role"
+}
+
+#RoleBinding: rbac_v1.#RoleBinding & {
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	kind:       "RoleBinding"
+}
+
+#ClusterRole: rbac_v1.#ClusterRole & {
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	kind:       "ClusterRole"
+}
+
+#ClusterRoleBinding: rbac_v1.#ClusterRoleBinding & {
+	apiVersion: "rbac.authorization.k8s.io/v1"
+	kind:       "ClusterRoleBinding"
+}
+
+#NetworkPolicy: net_v1.#NetworkPolicy & {
+	apiVersion: "networking.k8s.io/v1"
+	kind:       "NetworkPolicy"
 }
 
 #Metadata: meta_v1.#ObjectMeta

--- a/app/objectmap.cue
+++ b/app/objectmap.cue
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"github.com/amir-ahmad/cue-k8s-modules/app/k8s"
+	eso_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/external-secrets.io/v1"
+	gateway_v1 "github.com/amir-ahmad/cue-k8s-modules/k8s-schema/pkg/gateway.networking.k8s.io/v1"
+)
+
+#ObjectMap: [T=("namespaced" | "clusterscoped")]: [K=string]: [N=string]: {
+	kind: string | *K
+	metadata: name: string | *N
+}
+
+// Add typing for a bunch of common resources
+
+// Namespaced resources
+#ObjectMap: namespaced: ConfigMap?: [string]:             k8s.#ConfigMap
+#ObjectMap: namespaced: Secret?: [string]:                k8s.#Secret
+#ObjectMap: namespaced: Service?: [string]:               k8s.#Service
+#ObjectMap: namespaced: Deployment?: [string]:            k8s.#Deployment
+#ObjectMap: namespaced: StatefulSet?: [string]:           k8s.#StatefulSet
+#ObjectMap: namespaced: DaemonSet?: [string]:             k8s.#DaemonSet
+#ObjectMap: namespaced: Job?: [string]:                   k8s.#Job
+#ObjectMap: namespaced: CronJob?: [string]:               k8s.#CronJob
+#ObjectMap: namespaced: Ingress?: [string]:               k8s.#Ingress
+#ObjectMap: namespaced: ServiceAccount?: [string]:        k8s.#ServiceAccount
+#ObjectMap: namespaced: Role?: [string]:                  k8s.#Role
+#ObjectMap: namespaced: RoleBinding?: [string]:           k8s.#RoleBinding
+#ObjectMap: namespaced: NetworkPolicy?: [string]:         k8s.#NetworkPolicy
+#ObjectMap: namespaced: PersistentVolumeClaim?: [string]: k8s.#PersistentVolumeClaim
+
+// Cluster scoped resources
+#ObjectMap: clusterscoped: Namespace?: [string]:          k8s.#Namespace
+#ObjectMap: clusterscoped: StorageClass?: [string]:       k8s.#StorageClass
+#ObjectMap: clusterscoped: ClusterRole?: [string]:        k8s.#ClusterRole
+#ObjectMap: clusterscoped: ClusterRoleBinding?: [string]: k8s.#ClusterRoleBinding
+
+// Some common CRDs
+#ObjectMap: namespaced: ExternalSecret?: [string]:           eso_v1.#ExternalSecret
+#ObjectMap: namespaced: SecretStore?: [string]:              eso_v1.#SecretStore
+#ObjectMap: clusterscoped: ClusterSecretStore?: [string]:    eso_v1.#ClusterSecretStore
+#ObjectMap: clusterscoped: ClusterExternalSecret?: [string]: eso_v1.#ClusterExternalSecret
+#ObjectMap: namespaced: Gateway?: [string]:                  gateway_v1.#Gateway
+#ObjectMap: namespaced: HTTPRoute?: [string]:                gateway_v1.#HTTPRoute
+#ObjectMap: namespaced: GRPCRoute?: [string]:                gateway_v1.#GRPCRoute
+#ObjectMap: namespaced: BackendTLSPolicy?: [string]:         gateway_v1.#BackendTLSPolicy
+#ObjectMap: clusterscoped: GatewayClass?: [string]:          gateway_v1.#GatewayClass

--- a/app/tests/clusterscoped_objects_test.txtar
+++ b/app/tests/clusterscoped_objects_test.txtar
@@ -1,0 +1,117 @@
+exec cue export -e out --out yaml ./apps/...
+cmp stdout golden.yaml
+
+-- apps/cluster-resources.cue --
+package app
+
+out: (#App & {config: {
+	name: "cluster-resources"
+
+	// Test cluster-scoped objects using the ObjectMap
+	object: clusterscoped: {
+		Namespace: "app-namespace": {
+			metadata: labels: {
+				"purpose": "application"
+				"security": "restricted"
+			}
+		}
+
+		ClusterRole: "pod-reader": {
+			rules: [{
+				apiGroups: [""]
+				resources: ["pods"]
+				verbs: ["get", "list", "watch"]
+			}, {
+				apiGroups: ["apps"]
+				resources: ["deployments", "replicasets"]
+				verbs: ["get", "list"]
+			}]
+		}
+
+		ClusterRoleBinding: "pod-reader-binding": {
+			subjects: [{
+				kind: "ServiceAccount"
+				name: "default"
+				namespace: "default"
+			}]
+			roleRef: {
+				kind: "ClusterRole"
+				name: "pod-reader"
+				apiGroup: "rbac.authorization.k8s.io"
+			}
+		}
+
+		StorageClass: "fast-storage": {
+			provisioner: "kubernetes.io/aws-ebs"
+			parameters: {
+				type: "gp3"
+				iops: "3000"
+				throughput: "125"
+			}
+			reclaimPolicy: "Retain"
+			allowVolumeExpansion: true
+			volumeBindingMode: "WaitForFirstConsumer"
+		}
+	}
+}}).out
+
+-- golden.yaml --
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: app-namespace
+    labels:
+      app.kubernetes.io/name: cluster-resources
+      purpose: application
+      security: restricted
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: pod-reader
+    labels:
+      app.kubernetes.io/name: cluster-resources
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - apps
+      resources:
+        - deployments
+        - replicasets
+      verbs:
+        - get
+        - list
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: pod-reader-binding
+    labels:
+      app.kubernetes.io/name: cluster-resources
+  subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: default
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: pod-reader
+- apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: fast-storage
+    labels:
+      app.kubernetes.io/name: cluster-resources
+  provisioner: kubernetes.io/aws-ebs
+  parameters:
+    type: gp3
+    iops: "3000"
+    throughput: "125"
+  reclaimPolicy: Retain
+  allowVolumeExpansion: true
+  volumeBindingMode: WaitForFirstConsumer

--- a/app/tests/crd_objects_test.txtar
+++ b/app/tests/crd_objects_test.txtar
@@ -1,0 +1,320 @@
+exec cue export -e out --out yaml ./apps/...
+cmp stdout golden.yaml
+
+-- apps/crds.cue --
+package app
+
+out: (#App & {config: {
+	name: "crd-app"
+	common: namespace: "crd-test"
+
+	// Test CRD objects using the ObjectMap
+	object: namespaced: {
+		ExternalSecret: "api-secrets": {
+			spec: {
+				refreshInterval: "1h"
+				secretStoreRef: {
+					name: "vault-backend"
+					kind: "SecretStore"
+				}
+				target: {
+					name: "api-credentials"
+					creationPolicy: "Owner"
+				}
+				data: [{
+					secretKey: "api-key"
+					remoteRef: {
+						key: "production/api/key"
+					}
+				}, {
+					secretKey: "api-secret"
+					remoteRef: {
+						key: "production/api/secret"
+					}
+				}]
+			}
+		}
+
+		SecretStore: "vault-backend": {
+			spec: {
+				provider: vault: {
+					server: "https://vault.example.com"
+					path: "secret"
+					version: "v2"
+					auth: kubernetes: {
+						mountPath: "kubernetes"
+						role: "external-secrets"
+						serviceAccountRef: name: "external-secrets"
+					}
+				}
+			}
+		}
+
+		Gateway: "api-gateway": {
+			spec: {
+				gatewayClassName: "istio"
+				listeners: [{
+					name: "http"
+					protocol: "HTTP"
+					port: 80
+					allowedRoutes: namespaces: from: "Same"
+				}, {
+					name: "https"
+					protocol: "HTTPS"
+					port: 443
+					tls: {
+						mode: "Terminate"
+						certificateRefs: [{
+							kind: "Secret"
+							name: "tls-cert"
+						}]
+					}
+					allowedRoutes: namespaces: from: "Same"
+				}]
+			}
+		}
+
+		HTTPRoute: "api-route": {
+			spec: {
+				parentRefs: [{
+					name: "api-gateway"
+				}]
+				hostnames: ["api.example.com"]
+				rules: [{
+					matches: [{
+						path: {
+							type: "PathPrefix"
+							value: "/api/v1"
+						}
+					}]
+					backendRefs: [{
+						name: "api-service"
+						port: 8080
+					}]
+				}]
+			}
+		}
+
+		GRPCRoute: "grpc-route": {
+			spec: {
+				parentRefs: [{
+					name: "api-gateway"
+				}]
+				hostnames: ["grpc.example.com"]
+				rules: [{
+					matches: [{
+						method: {
+							type: "Exact"
+							service: "api.v1.ApiService"
+						}
+					}]
+					backendRefs: [{
+						name: "grpc-service"
+						port: 9090
+					}]
+				}]
+			}
+		}
+
+		BackendTLSPolicy: "backend-tls": {
+			spec: {
+				targetRefs: [{
+					group: ""	
+					kind: "Service"
+					name: "secure-backend"
+				}]
+				validation: {
+					caCertificateRefs: [{
+						group: ""
+						kind: "ConfigMap"
+						name: "backend-ca"
+					}]
+					hostname: "backend.internal"
+				}
+			}
+		}
+	}
+
+	object: clusterscoped: {
+		ClusterSecretStore: "vault-cluster": {
+			spec: {
+				provider: vault: {
+					server: "https://vault.example.com"
+					path: "secret"
+					version: "v2"
+					auth: kubernetes: {
+						mountPath: "kubernetes"
+						role: "cluster-external-secrets"
+						serviceAccountRef: {
+							name: "external-secrets"
+							namespace: "external-secrets-system"
+						}
+					}
+				}
+			}
+		}
+
+		GatewayClass: "istio": {
+			spec: {
+				controllerName: "istio.io/gateway-controller"
+				description: "Istio-based gateway class"
+			}
+		}
+	}
+}}).out
+
+-- golden.yaml --
+- apiVersion: external-secrets.io/v1
+  kind: ExternalSecret
+  metadata:
+    name: api-secrets
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    data:
+      - remoteRef:
+          key: production/api/key
+        secretKey: api-key
+      - remoteRef:
+          key: production/api/secret
+        secretKey: api-secret
+    refreshInterval: 1h
+    secretStoreRef:
+      kind: SecretStore
+      name: vault-backend
+    target:
+      creationPolicy: Owner
+      name: api-credentials
+- apiVersion: external-secrets.io/v1
+  kind: SecretStore
+  metadata:
+    name: vault-backend
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    provider:
+      vault:
+        auth:
+          kubernetes:
+            mountPath: kubernetes
+            role: external-secrets
+            serviceAccountRef:
+              name: external-secrets
+        path: secret
+        server: https://vault.example.com
+        version: v2
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: api-gateway
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    gatewayClassName: istio
+    listeners:
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: http
+        port: 80
+        protocol: HTTP
+      - allowedRoutes:
+          namespaces:
+            from: Same
+        name: https
+        port: 443
+        protocol: HTTPS
+        tls:
+          certificateRefs:
+            - kind: Secret
+              name: tls-cert
+          mode: Terminate
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: api-route
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    hostnames:
+      - api.example.com
+    parentRefs:
+      - name: api-gateway
+    rules:
+      - backendRefs:
+          - name: api-service
+            port: 8080
+        matches:
+          - path:
+              type: PathPrefix
+              value: /api/v1
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: GRPCRoute
+  metadata:
+    name: grpc-route
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    hostnames:
+      - grpc.example.com
+    parentRefs:
+      - name: api-gateway
+    rules:
+      - backendRefs:
+          - name: grpc-service
+            port: 9090
+        matches:
+          - method:
+              service: api.v1.ApiService
+              type: Exact
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    name: backend-tls
+    namespace: crd-test
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    targetRefs:
+      - group: ""
+        kind: Service
+        name: secure-backend
+    validation:
+      caCertificateRefs:
+        - group: ""
+          kind: ConfigMap
+          name: backend-ca
+      hostname: backend.internal
+- apiVersion: external-secrets.io/v1
+  kind: ClusterSecretStore
+  metadata:
+    name: vault-cluster
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    provider:
+      vault:
+        auth:
+          kubernetes:
+            mountPath: kubernetes
+            role: cluster-external-secrets
+            serviceAccountRef:
+              name: external-secrets
+              namespace: external-secrets-system
+        path: secret
+        server: https://vault.example.com
+        version: v2
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: GatewayClass
+  metadata:
+    name: istio
+    labels:
+      app.kubernetes.io/name: crd-app
+  spec:
+    controllerName: istio.io/gateway-controller
+    description: Istio-based gateway class

--- a/app/tests/custom_objects_test.txtar
+++ b/app/tests/custom_objects_test.txtar
@@ -6,31 +6,10 @@ package app
 
 out: (#App & {config: {
 	name: "monitoring"
-	common: {
-		namespace: "monitoring"
-		labels: {
-			"environment": "production"
-			"team": "platform"
-		}
-	}
-
-	controller: prometheus: {
-		type: "Deployment"
-		pod: {
-			image: "prom/prometheus:v2.45.0"
-			ports: http: {
-				port: 9090
-				expose: true
-			}
-			env: {
-				PROMETHEUS_RETENTION: "30d"
-			}
-		}
-		spec: replicas: 1
-	}
+	common: namespace: "monitoring"
 
 	// Custom objects using the object field
-	object: {
+	object: namespaced: {
 		ServiceMonitor: "prometheus-sm": {
 			apiVersion: "monitoring.coreos.com/v1"
 			spec: {
@@ -43,81 +22,17 @@ out: (#App & {config: {
 				}]
 			}
 		}
-		
-		NetworkPolicy: "deny-all": {
-			apiVersion: "networking.k8s.io/v1"
-			spec: {
-				podSelector: {}
-				policyTypes: ["Ingress", "Egress"]
-			}
-		}
 	}
 }}).out
 
 -- golden.yaml --
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: prometheus
-    namespace: monitoring
-    labels:
-      app.kubernetes.io/name: monitoring
-      app.kubernetes.io/component: prometheus
-      environment: production
-      team: platform
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app.kubernetes.io/name: monitoring
-        app.kubernetes.io/component: prometheus
-    template:
-      metadata:
-        labels:
-          app.kubernetes.io/name: monitoring
-          app.kubernetes.io/component: prometheus
-        annotations: {}
-      spec:
-        containers:
-          - name: prometheus
-            image: prom/prometheus:v2.45.0
-            ports:
-              - name: http
-                containerPort: 9090
-                protocol: TCP
-            env:
-              - name: PROMETHEUS_RETENTION
-                value: 30d
-            imagePullPolicy: IfNotPresent
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: prometheus
-    namespace: monitoring
-    labels:
-      app.kubernetes.io/name: monitoring
-      app.kubernetes.io/component: prometheus
-      environment: production
-      team: platform
-  spec:
-    ports:
-      - name: http
-        port: 9090
-        protocol: TCP
-        targetPort: 9090
-    selector:
-      app.kubernetes.io/name: monitoring
-      app.kubernetes.io/component: prometheus
-    type: ClusterIP
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
-    name: prometheus-sm
-    namespace: monitoring
     labels:
       app.kubernetes.io/name: monitoring
-      environment: production
-      team: platform
+    name: prometheus-sm
+    namespace: monitoring
   spec:
     selector:
       matchLabels:
@@ -125,17 +40,3 @@ out: (#App & {config: {
     endpoints:
       - port: http
         path: /metrics
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: deny-all
-    namespace: monitoring
-    labels:
-      app.kubernetes.io/name: monitoring
-      environment: production
-      team: platform
-  spec:
-    podSelector: {}
-    policyTypes:
-      - Ingress
-      - Egress

--- a/app/tests/namespace_only_test.txtar
+++ b/app/tests/namespace_only_test.txtar
@@ -1,0 +1,19 @@
+exec cue export -e out --out yaml ./apps/...
+cmp stdout golden.yaml
+
+-- apps/foo.cue --
+package app
+
+out: (#App & {config: {
+	name: "foo"
+
+	object: clusterscoped: Namespace: "foo-ns": {}
+}}).out
+
+-- golden.yaml --
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: foo-ns
+    labels:
+      app.kubernetes.io/name: foo

--- a/app/tests/namespaced_objects_test.txtar
+++ b/app/tests/namespaced_objects_test.txtar
@@ -1,0 +1,130 @@
+exec cue export -e out --out yaml ./apps/...
+cmp stdout golden.yaml
+
+-- apps/rbac-app.cue --
+package app
+
+out: (#App & {config: {
+	name: "rbac-app"
+	common: namespace: "namespaced-test"
+
+	// Test various namespaced objects using the ObjectMap
+	object: namespaced: {
+		Secret: "db-credentials": {
+			stringData: {
+				username: "admin"
+				password: "secret123"
+			}
+		}
+
+		ServiceAccount: "app-sa": {
+			automountServiceAccountToken: false
+		}
+
+		Role: "app-role": {
+			rules: [{
+				apiGroups: [""]
+				resources: ["pods", "services"]
+				verbs: ["get", "list", "watch"]
+			}, {
+				apiGroups: ["apps"]
+				resources: ["deployments"]
+				verbs: ["get", "list"]
+			}]
+		}
+
+		RoleBinding: "app-rb": {
+			subjects: [{
+				kind: "ServiceAccount"
+				name: "app-sa"
+				namespace: "test-ns"
+			}]
+			roleRef: {
+				kind: "Role"
+				name: "app-role"
+				apiGroup: "rbac.authorization.k8s.io"
+			}
+		}
+
+		PersistentVolumeClaim: "data-pvc": {
+			spec: {
+				accessModes: ["ReadWriteOnce"]
+				resources: requests: storage: "10Gi"
+				storageClassName: "fast-ssd"
+			}
+		}
+	}
+}}).out
+
+-- golden.yaml --
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: db-credentials
+    namespace: namespaced-test
+    labels:
+      app.kubernetes.io/name: rbac-app
+  stringData:
+    username: admin
+    password: secret123
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: app-sa
+    namespace: namespaced-test
+    labels:
+      app.kubernetes.io/name: rbac-app
+  automountServiceAccountToken: false
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: app-role
+    namespace: namespaced-test
+    labels:
+      app.kubernetes.io/name: rbac-app
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+        - services
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - apps
+      resources:
+        - deployments
+      verbs:
+        - get
+        - list
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: app-rb
+    namespace: namespaced-test
+    labels:
+      app.kubernetes.io/name: rbac-app
+  subjects:
+    - kind: ServiceAccount
+      name: app-sa
+      namespace: test-ns
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: app-role
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: data-pvc
+    namespace: namespaced-test
+    labels:
+      app.kubernetes.io/name: rbac-app
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+    storageClassName: fast-ssd

--- a/app/tests/object_error_invalid_spec_test.txtar
+++ b/app/tests/object_error_invalid_spec_test.txtar
@@ -1,0 +1,13 @@
+! exec cue export -e out --out yaml ./apps/...
+stderr 'mismatched types string and int'
+
+-- apps/foo.cue --
+package app
+
+out: (#App & {config: {
+	name: "foo"
+	common: namespace: "default"
+
+	// Invalid spec: replicas should be a number, not a string
+	object: namespaced: Deployment: "invalid": spec: replicas: "three"  
+}}).out

--- a/app/tests/object_only_test.txtar
+++ b/app/tests/object_only_test.txtar
@@ -1,0 +1,25 @@
+exec cue export -e out --out yaml ./apps/...
+cmp stdout golden.yaml
+
+-- apps/foo.cue --
+package app
+
+out: (#App & {config: {
+	name: "foo"
+	common: namespace: "default"
+
+	object: namespaced: ConfigMap: "foo": {
+		data: key: "value"
+	}
+}}).out
+
+-- golden.yaml --
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: foo
+    namespace: default
+    labels:
+      app.kubernetes.io/name: foo
+  data:
+    key: value


### PR DESCRIPTION
- It's useful to have typing out of the box on a bunch of common resources, which is now done.
- Split up namespaced vs clusterscoped objects so we can only set common.namespace on the former.